### PR TITLE
Make sure nodename is fully qualified.

### DIFF
--- a/makehostkeys
+++ b/makehostkeys
@@ -3,7 +3,7 @@
 REALM='FNAL.GOV'
 DEFAULT_SERVICES='host'
 KEYTAB='/etc/krb5.keytab'
-NODENAME=$(hostname)
+NODENAME=$(hostname --fqdn)
 PASSWORD=""
 
 ###########################################################


### PR DESCRIPTION
Hello,  I ran the makehostkeys script on a new AlmaLinux 9 installation with Fermilab context packages and it failed because the script defaulted to host/mu2e07@FNAL.GOV  instead of host/mu2e07.fnal.gov@FNAL.GOV
See Fermilab RITM1946472
This patch is supposed to fix the issue.
